### PR TITLE
Remove `linux-headers` apk from Dockerfile (upstream backport to release-4.15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /usr/src/ib-sriov-cni
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 linux-headers=~6.3
+RUN apk add --no-cache --virtual build-dependencies build-base=~0.5
 WORKDIR /usr/src/ib-sriov-cni
 RUN make clean && \
     make build


### PR DESCRIPTION
Backport commit fc002af57a81855542759d0f77d16dacd7e1aa38 to `release-4.15` branch. This is upstream https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/84

Otherwise, build fails:

```
$ podman build -t foo -f Dockerfile
[1/2] STEP 1/7: FROM golang:1.20-alpine AS builder
[1/2] STEP 2/7: COPY . /usr/src/ib-sriov-cni
--> a78ca05e4982
[1/2] STEP 3/7: ENV HTTP_PROXY $http_proxy
--> a75387849f14
[1/2] STEP 4/7: ENV HTTPS_PROXY $https_proxy
--> 9c3cddc0ab98
[1/2] STEP 5/7: RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 linux-headers=~6.3
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  linux-headers-6.5-r0:
    breaks: build-dependencies-20240613.095259[linux-headers~6.3]
  build-dependencies-20240613.095259:
    masked in: cache
    satisfies: world[build-dependencies=20240613.095259]
Error: building at STEP "RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 linux-headers=~6.3": while running runtime: exit status 2
```