### PR TITLE
OCPBUGS-48587: Revert "[release-4.14] switch base image to rhel 9"

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -16,7 +16,7 @@ WORKDIR /usr/src/ib-sriov-cni
 RUN make clean && \
    GO_TAGS="" GO_BUILD_OPTS=CGO_ENABLED=1 make build
 
-FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.14:base
 
 COPY --from=builder-rhel9 /usr/src/ib-sriov-cni/build/ib-sriov /usr/bin/
 


### PR DESCRIPTION
Reverts openshift/ib-sriov-cni#71

as requested by the ART team