### PR TITLE
add .0 for go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/ib-sriov-cni
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/containernetworking/cni v1.3.0


### PR DESCRIPTION
Hermeto errors out if its missing the `.0` for go versions >= `1.22`