### PR TITLE
OCPBUGS-65711: Add support for CentOS Stream CoreOS in entrypoint script

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -36,7 +36,7 @@ get_source_folder_for_rhel_version()
                 rhelmajor="$(echo "$PLATFORM_ID" | sed -E 's/^platform:el([0-9]+)$/\1/')"
             fi
         ;;
-        rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+        rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
         ;;
         fedora)
             if [ "${VARIANT_ID}" = "coreos" ]; then


### PR DESCRIPTION
The script previously failed when encountering CentOS Stream CoreOS (ID=centos) in OKD clusters. This change adds centos to the supported OS IDs, allowing it to extract the RHEL major version from VERSION_ID, similar to how rhel is handled.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>
